### PR TITLE
Add TypeName bounds to impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,9 @@
 //! ```rust,ignore
 //! #[macro_use] extern crate typename;
 //!
+//! // Note that Custom<T> will only implement TypeName when T does, too.
 //! #[derive(TypeName)]
-//! struct Custom<T: TypeName> {
+//! struct Custom<T> {
 //!     some_t: T,
 //! }
 //! ```
@@ -66,8 +67,8 @@ pub mod fmt;
 ///
 /// ## Derivable
 ///
-/// This trait can be used with `#[derive(TypeName)]`. Any generic parameters
-/// to a type must implement `TypeName` as well.
+/// This trait can be used with `#[derive(TypeName)]`. The derived impl will require that
+/// any generic parameters to the type implement `TypeName` as well.
 ///
 /// ## How can I implement `TypeName`?
 ///

--- a/typename_derive/tests/tests.rs
+++ b/typename_derive/tests/tests.rs
@@ -21,12 +21,13 @@ enum SomeEnum {
     _B,
 }
 
-// The TypeName bound is no longer needed; we'll add it to the impl instead.
+// You don't need to add a TypeName bound to the struct's type parameter; we'll automatically add
+// that bound to the TypeName impl that gets derived.
 #[derive(Clone, TypeName)]
 struct TupleStruct<T>(T);
 
-// We add the TypeName bound to impl even if there are other bounds on the type parameter, and even
-// if you (now redundantly) specific a TypeName bound yourself.
+// Test that we correctly add the TypeName bound to the impl even if there are other bounds on the
+// type parameter, and even if you (now redundantly) specify a TypeName bound yourself.
 #[derive(TypeName)]
 struct Struct<T: Clone, S: Clone + TypeName> {
     _t: T,

--- a/typename_derive/tests/tests.rs
+++ b/typename_derive/tests/tests.rs
@@ -21,11 +21,14 @@ enum SomeEnum {
     _B,
 }
 
-#[derive(TypeName)]
-struct TupleStruct<T: TypeName>(T);
+// The TypeName bound is no longer needed; we'll add it to the impl instead.
+#[derive(Clone, TypeName)]
+struct TupleStruct<T>(T);
 
+// We add the TypeName bound to impl even if there are other bounds on the type parameter, and even
+// if you (now redundantly) specific a TypeName bound yourself.
 #[derive(TypeName)]
-struct Struct<T: TypeName, S: TypeName> {
+struct Struct<T: Clone, S: Clone + TypeName> {
     _t: T,
     _s: S,
 }

--- a/typename_derive/tests/tests.rs
+++ b/typename_derive/tests/tests.rs
@@ -12,10 +12,10 @@ extern crate typename;
 
 use typename::TypeName;
 
-#[derive(TypeName)]
+#[derive(Clone, TypeName)]
 struct UnitStruct;
 
-#[derive(TypeName)]
+#[derive(Clone, TypeName)]
 enum SomeEnum {
     _A,
     _B,

--- a/typename_derive/tests/tests.rs
+++ b/typename_derive/tests/tests.rs
@@ -15,7 +15,7 @@ use typename::TypeName;
 #[derive(Clone, TypeName)]
 struct UnitStruct;
 
-#[derive(Clone, TypeName)]
+#[derive(TypeName)]
 enum SomeEnum {
     _A,
     _B,
@@ -23,7 +23,7 @@ enum SomeEnum {
 
 // You don't need to add a TypeName bound to the struct's type parameter; we'll automatically add
 // that bound to the TypeName impl that gets derived.
-#[derive(Clone, TypeName)]
+#[derive(TypeName)]
 struct TupleStruct<T>(T);
 
 // Test that we correctly add the TypeName bound to the impl even if there are other bounds on the


### PR DESCRIPTION
When deriving TypeName for a generic type, you no longer need to add explicit TypeName bounds to your type parameters.  Instead, we'll add those bounds to the impl that we create, mimicking how Clone and friends are derived.  So instead of

``` rust
#[derive(TypeName)]
struct MyVec<T: TypeName>;
```

you can now do

``` rust
#[derive(TypeName)]
struct MyVec<T>;
```