### PR TITLE
More Types Added

### DIFF
--- a/src/imp.rs
+++ b/src/imp.rs
@@ -97,8 +97,8 @@ derive_type_name!(std::option::Option<T>);
 derive_type_name!(std::result::Result<T, E>);
 derive_type_name!(std::rc::Rc<T>);
 derive_type_name!(std::path::PathBuf);
-derive_type_name!(std::sync::Arc);
-derive_type_name!(std::sync::RwLock);
+derive_type_name!(std::sync::Arc<T>);
+derive_type_name!(std::sync::RwLock<T>);
 derive_type_name!(std::sync::mpsc::Receiever);
 derive_type_name!(std::sync::mpsc::Sender);
 

--- a/src/imp.rs
+++ b/src/imp.rs
@@ -248,5 +248,8 @@ mod tests {
         assert_eq_name::<[::std::rc::Rc<i32>; 5]>();
         assert_eq_name::<::std::marker::PhantomData<&i32>>();
         assert_eq_name::<::std::sync::Arc<i32>>();
+        assert_eq_name::<::std::sync::mpsc::Receiver<i32>>();
+        assert_eq_name::<::std::sync::mpsc::Sender<i32>>();
+        assert_eq_name::<::std::path::PathBuf>();
     }
 }

--- a/src/imp.rs
+++ b/src/imp.rs
@@ -97,6 +97,10 @@ derive_type_name!(std::option::Option<T>);
 derive_type_name!(std::result::Result<T, E>);
 derive_type_name!(std::rc::Rc<T>);
 derive_type_name!(std::path::PathBuf);
+derive_type_name!(std::sync::Arc);
+derive_type_name!(std::sync::RwLock);
+derive_type_name!(std::sync::mpsc::Receiever);
+derive_type_name!(std::sync::mpsc::Sender);
 
 // the empty and singleton tuple are special cases
 impl ::TypeName for () {

--- a/src/imp.rs
+++ b/src/imp.rs
@@ -99,8 +99,8 @@ derive_type_name!(std::rc::Rc<T>);
 derive_type_name!(std::path::PathBuf);
 derive_type_name!(std::sync::Arc<T>);
 derive_type_name!(std::sync::RwLock<T>);
-derive_type_name!(std::sync::mpsc::Receiever);
-derive_type_name!(std::sync::mpsc::Sender);
+derive_type_name!(std::sync::mpsc::Receiver<T>);
+derive_type_name!(std::sync::mpsc::Sender<T>);
 
 // the empty and singleton tuple are special cases
 impl ::TypeName for () {

--- a/src/imp.rs
+++ b/src/imp.rs
@@ -247,5 +247,6 @@ mod tests {
         assert_eq_name::<&mut Box<Vec<(bool, i32)>>>();
         assert_eq_name::<[::std::rc::Rc<i32>; 5]>();
         assert_eq_name::<::std::marker::PhantomData<&i32>>();
+        assert_eq_name::<::std::sync::Arc<i32>>();
     }
 }


### PR DESCRIPTION
I've added more types. I did run into an issue with the `std::sync::Arc` type. It passes the unit test, but I get this error when I try to run my tests: 
```
error[E0599]: no function or associated item named `type_name` found for type `std::sync::Arc<i32>` in the current scope
   --> src/lib.rs:405:25
    |
405 |             Arc::<i32>::type_name();
    |             ------------^^^^^^^^^
    |             |
    |             function or associated item not found in `std::sync::Arc<i32>`
    |
    = note: the method `type_name` exists but the following trait bounds were not satisfied:
            `&mut std::sync::Arc<i32> : typename::TypeName`
            `&std::sync::Arc<i32> : typename::TypeName`
```
This is a runtime error.

I'm reporting this here because it didn't seem to make sense to open an issue for code the repo didn't have.