### PR TITLE
Update syn and quote versions to 1.0

### DIFF
--- a/typename_derive/Cargo.toml
+++ b/typename_derive/Cargo.toml
@@ -12,8 +12,8 @@ name = "typename_derive"
 proc-macro = true
 
 [dependencies]
-syn = "^0.15"
-quote = "^0.6"
+syn = "1.0"
+quote = "1.0"
 
 [dev-dependencies.typename]
 path = ".."


### PR DESCRIPTION
Since `syn` and `quote` are now at 1.0, it would be good to update them, so that users depending on `typename` don't get duplicated versions of these crates in their dependency trees.

I wasn't sure whether to set the versions to "1.0" or something like "^1". I noticed that `serde` uses "1.0" for its dependencies on `syn` and `quote`, so I went with that as well.

Note that there are some currently failing tests, which is independent of my change. I suppose the intrinsic for type names has changed its output for some types.